### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project demonstrates how to create a MCP server that interacts with the Monad testnet. The MCP server provides a tool for checking MON token balances on the Monad testnet.
 
+<a href="https://glama.ai/mcp/servers/@bble/monad-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bble/monad-mcp/badge" alt="Monad MCP server" />
+</a>
+
 ## What is MCP?
 
 The Model Context Protocol (MCP) is a standard that allows AI models to interact with external tools and services. 
@@ -151,7 +155,6 @@ server.tool(
 );
 ```
 
-
 ### Initialize the transport and server from the `main` function
 
 ```ts
@@ -219,4 +222,3 @@ Here's the final result
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io/introduction)
 - [Monad Documentation](https://docs.monad.xyz/)
 - [Viem Documentation](https://viem.sh/)
-


### PR DESCRIPTION
This PR adds a badge for the [Monad MCP](https://glama.ai/mcp/servers/@bble/monad-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bble/monad-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bble/monad-mcp/badge" alt="Monad MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.